### PR TITLE
Handle failed requests that do not contain errors

### DIFF
--- a/src/Economic.php
+++ b/src/Economic.php
@@ -358,7 +358,10 @@ class Economic
 
         if (isset($formattedResponse->message)) {
             $this->lastError = sprintf('%d: %s', $formattedResponse->httpStatusCode, $formattedResponse->message);
-            $this->errors = $formattedResponse->errors;
+            
+            if (isset($formattedResponse->errors)) {
+                $this->errors = $formattedResponse->errors;
+            }
             return false;
         }
 


### PR DESCRIPTION
Some responses from e-conomic do not return `errors`.
For instance, 404 errors return a response that looks like this:

```
"message": "Resource not found.",
"developerHint": "The API tries to provide all the resource urls you need. If you have hard coded urls yourself, then try to look at the enclosing collection for hypermedia information on where the resource you are looking for could be.",
"logId": "377aeee92480bbc72a28eaeb2cc1dbe0",
"httpStatusCode": 404,
"logTime": "2017-09-28T15:37:32",
```

This simple change checks if `$formattedResponse->errors` is set, and only updates `$this->errors` when that's the case.